### PR TITLE
Ensure whitespace before keywords

### DIFF
--- a/WDL.YAML-tmLanguage
+++ b/WDL.YAML-tmLanguage
@@ -75,7 +75,7 @@ repository:
   keywords:
     patterns:
     - name: keyword.other.wdl
-      match: \s*(call|command|output|runtime|task|workflow|if|then|else|import|as|input|output|meta|parameter_meta|scatter)\s+
+      match: (^|\s)(call|command|output|runtime|task|workflow|if|then|else|import|as|input|output|meta|parameter_meta|scatter)[^A-Za-z_]
 
   string_quoted_double:
     patterns:

--- a/WDL.tmLanguage
+++ b/WDL.tmLanguage
@@ -205,7 +205,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\s*(call|command|output|runtime|task|workflow|if|then|else|import|as|input|output|meta|parameter_meta|scatter)\s+</string>
+					<string>(^|\s)(call|command|output|runtime|task|workflow|if|then|else|import|as|input|output|meta|parameter_meta|scatter)[^A-Za-z_]</string>
 					<key>name</key>
 					<string>keyword.other.wdl</string>
 				</dict>


### PR DESCRIPTION
Neaten matching of keywords to avoid highlighting `something_input` as a keyword