### PR TITLE
ACE Editor Syntax Highlighting Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This repo provides support for the [Workflow Description Language (WDL)](https:/
  #### Visual Studio Code:
  * Go to Extensions, search for WDL Syntax Highlighter and install!
  
+### Converting WDL.tmLanguage (TextMate) to ACE Editor
+Follow steps here [Importing .tmltheme and .tmlanguage Files into Ace](https://github.com/ajaxorg/ace/wiki/Importing-.tmtheme-and-.tmlanguage-Files-into-Ace#importing-textmatesublime-languages)
+
+Note that the conversion is not always perfect. For example, TextMate uses Javascript which does not support look behinds. This must be fixed for the builtin_types lookbehind.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ This repo provides support for the [Workflow Description Language (WDL)](https:/
 ### Converting WDL.tmLanguage (TextMate) to ACE Editor
 Follow steps here [Importing .tmltheme and .tmlanguage Files into Ace](https://github.com/ajaxorg/ace/wiki/Importing-.tmtheme-and-.tmlanguage-Files-into-Ace#importing-textmatesublime-languages)
 
-Note that the conversion is not always perfect. For example, TextMate uses Javascript which does not support look behinds. This must be fixed for the builtin_types lookbehind.
+Note that the conversion is not always perfect. For example, ACE editor uses Javascript which does not support look behinds. This must be fixed for the builtin_types lookbehind.

--- a/ace/wdl_highlight_rules.js
+++ b/ace/wdl_highlight_rules.js
@@ -1,0 +1,167 @@
+define(function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var WDLHighlightRules = function() {
+    // regexp must not have capturing parentheses. Use (?:) instead.
+    // regexps are ordered -> the first match is used
+
+    this.$rules = {
+        start: [{
+            token: "keyword.operator.assignment.wdl",
+            regex: /\=/
+        }, {
+            token: "keyword.operator.comparison.wdl",
+            regex: /<\=|>\=|\=\=|<|>|\!\=/
+        }, {
+            token: "keyword.operator.assignment.augmented.wdl",
+            regex: /\+\=|-\=|\*\=|\/\=|\/\/\=|%\=|&\=|\|\=|\^\=|>>\=|<<\=|\*\*\=/
+        }, {
+            token: "keyword.operator.arithmetic.wdl",
+            regex: /\+|\-|\*|\*\*|\/|\/\/|%|<<|>>|&|\||\^|~/
+        }, {
+            token: "constant.language.wdl",
+            regex: /\b(?:true|false)\b/
+        }, {
+            include: "#builtin_types"
+        }, {
+            include: "#comments"
+        }, {
+            include: "#input_output"
+        }, {
+            include: "#keywords"
+        }, {
+            include: "#string_quoted_single"
+        }, {
+            include: "#string_quoted_double"
+        }, {
+            include: "#command_block"
+        }],
+        "#builtin_types": [{
+            token: "support.type.wdl",
+            regex: "(?:[^A-Za-z0-9_\.])(?:Array|Boolean|File|Float|Int|Map|Object|String|Pair)\\b",
+        }],
+        "#command_block": [{
+            token: [
+                "keyword.other.wdl",
+                "command.block.wdl",
+                "command.block.wdl"
+            ],
+            regex: /(command)(\s*\{)((?:$|\s)*)/,
+            push: [{
+                token: "command.block.wdl",
+                regex: /(?:^|\s+)\}/,
+                next: "pop"
+            }, {
+                defaultToken: "command.block.wdl"
+            }],
+            comment: "command {}"
+        }, {
+            token: [
+                "keyword.other.wdl",
+                "command.block.wdl",
+                "command.block.wdl"
+            ],
+            regex: /(command)(\s*<{3})((?:$|\s)*)/,
+            push: [{
+                token: "command.block.wdl",
+                regex: /(?:^|\s+)>{3}/,
+                next: "pop"
+            }, {
+                defaultToken: "command.block.wdl"
+            }],
+            comment: "command <<< >>>"
+        }],
+        "#comments": [{
+            token: [
+                "punctuation.definition.comment.wdl",
+                "comment.line.number-sign.wdl"
+            ],
+            regex: /(#)(.*$)/
+        }],
+        "#constant_placeholder": [{
+            token: "constant.other.placeholder.wdl",
+            regex: /%(?:\([a-z_]+\))?#?0?\-?[ ]?\+?(?:[0-9]*|\*)(?:\.(?:[0-9]*|\*))?[hL]?[a-z%]/,
+            caseInsensitive: true
+        }],
+        "#escaped_char": [{
+            token: [
+                "constant.character.escape.hex.wdl",
+                "constant.character.escape.octal.wdl",
+                "constant.character.escape.newline.wdl",
+                "constant.character.escape.backlash.wdl",
+                "constant.character.escape.double-quote.wdl",
+                "constant.character.escape.single-quote.wdl",
+                "constant.character.escape.bell.wdl",
+                "constant.character.escape.backspace.wdl",
+                "constant.character.escape.formfeed.wdl",
+                "constant.character.escape.linefeed.wdl",
+                "constant.character.escape.return.wdl",
+                "constant.character.escape.tab.wdl",
+                "constant.character.escape.vertical-tab.wdl"
+            ],
+            regex: /(\\x[0-9a-fA-F]{2})|(\\[0-7]{3})|(\\$)|(\\\\)|(\\\")|(\\')|(\\a)|(\\b)|(\\f)|(\\n)|(\\r)|(\\t)|(\\v)/
+        }],
+        "#escaped_unicode_char": [{
+            token: [
+                "constant.character.escape.unicode.16-bit-hex.wdl",
+                "constant.character.escape.unicode.32-bit-hex.wdl",
+                "constant.character.escape.unicode.name.wdl"
+            ],
+            regex: /(\\U[0-9A-Fa-f]{8})|(\\u[0-9A-Fa-f]{4})|(\\N\{[a-zA-Z0-9\, ]+\})/
+        }],
+        "#keywords": [{
+            token: "keyword.other.wdl",
+            regex: /(?:^|\s)(?:call|runtime|task|workflow|if|then|else|import|as|input|output|meta|parameter_meta|scatter)[^A-Za-z_]/
+        }],
+        "#string_quoted_double": [{
+            token: "punctuation.definition.string.begin.wdl",
+            regex: /"/,
+            push: [{
+                token: "punctuation.definition.string.end.wdl",
+                regex: /"/,
+                next: "pop"
+            }, {
+                include: "#constant_placeholder"
+            }, {
+                include: "#escaped_char"
+            }, {
+                defaultToken: "string.quoted.double.single-line.wdl"
+            }],
+            comment: "double quoted string"
+        }],
+        "#string_quoted_single": [{
+            token: "punctuation.definition.string.begin.wdl",
+            regex: /'/,
+            push: [{
+                token: "punctuation.definition.string.end.wdl",
+                regex: /'/,
+                next: "pop"
+            }, {
+                include: "#constant_placeholder"
+            }, {
+                include: "#escaped_char"
+            }, {
+                defaultToken: "string.quoted.single.single-line.wdl"
+            }],
+            comment: "single quoted string"
+        }]
+    }
+    
+    this.normalizeRules();
+};
+
+WDLHighlightRules.metaData = {
+    author: "Andrew Teixeira <teixeira@broadinstitute.org>",
+    fileTypes: ["wdl"],
+    name: "WDL",
+    scopeName: "source.wdl"
+}
+
+
+oop.inherits(WDLHighlightRules, TextHighlightRules);
+
+exports.WDLHighlightRules = WDLHighlightRules;
+});


### PR DESCRIPTION
I have added syntax highlighting support for ACE Editor for use with Dockstore.org and thought it might be useful for someone else in the future.

The process to reproduce isn't completely automated, however it is pretty straightforward. I steps are outlined in the README.

Let me know if you want anything changed such as filename conventions, more documentation, etc.